### PR TITLE
Fix incorrect URL if IP changes after img uploaded

### DIFF
--- a/add-custom-header-images.php
+++ b/add-custom-header-images.php
@@ -116,7 +116,7 @@ class Add_Custom_Header_Images {
 			$thumb = wp_get_attachment_image_src( $image->ID, 'medium' );
 
 			$headers[] = array(
-				'url'           => $image->guid,
+				'url'           => wp_get_attachment_url($image->ID),
 				'thumbnail_url' => $thumb[0],
 				'description'   => $image->post_title,
 				'attachment_id' => $image->ID,


### PR DESCRIPTION
previously image url was $image->guid, however this can be incorrect if the IP address of site changes. using wp_get_attachment_url is 'smart' and takes IP changes into consideration.